### PR TITLE
Handle non-catchable raids / Language Updates Source Upstream Pull

### DIFF
--- a/TeraFinder.Core/Classes/EncounterTF9/EncounterRaidTF9.cs
+++ b/TeraFinder.Core/Classes/EncounterTF9/EncounterRaidTF9.cs
@@ -52,6 +52,8 @@ public abstract record EncounterRaidTF9 : IExtendedTeraRaid9
     public string LongName => Name;
     public string Name => $"{(IsMighty ? "Mighty " : "")}{(Species)Species}-{Form}";
 
+    public bool CanBeCaught => Identifier != 2025072301u; //Shiny Wo-Chien
+
     public abstract bool CanBeEncountered(uint seed);
 
     //Generate Tera Details with no Filters;

--- a/TeraFinder.Core/Resources/translations/lang_de.txt
+++ b/TeraFinder.Core/Resources/translations/lang_de.txt
@@ -361,3 +361,4 @@ GridUtil.CheckWiki=Please check the Tera Finder wiki to find out how to update t
 GridUtil.Report=Please report this error to the Tera Finder author.
 GridUtil.RowsExceeded=Rows selection exceeded the maximum allowed [1].
 GridUtil.MismatchGroupID=GroupID Mismatch. The selected Raid Den on the Raid Editor can only contain Event Raids with index {editorIndex}. The selected Raid result has Index {resultIndex}.
+GridUtil.NoCatch=This Pokémon cannot be caught.

--- a/TeraFinder.Core/Resources/translations/lang_en.txt
+++ b/TeraFinder.Core/Resources/translations/lang_en.txt
@@ -361,3 +361,4 @@ GridUtil.CheckWiki=Please check the Tera Finder wiki to find out how to update t
 GridUtil.Report=Please report this error to the Tera Finder author.
 GridUtil.RowsExceeded=Rows selection exceeded the maximum allowed [1].
 GridUtil.MismatchGroupID=GroupID Mismatch. The selected Raid Den on the Raid Editor can only contain Event Raids with index {editorIndex}. The selected Raid result has Index {resultIndex}.
+GridUtil.NoCatch=This Pokémon cannot be caught.

--- a/TeraFinder.Core/Resources/translations/lang_es.txt
+++ b/TeraFinder.Core/Resources/translations/lang_es.txt
@@ -361,3 +361,4 @@ GridUtil.CheckWiki=Por favor, consulta wiki de Tera Finder para saber cómo actu
 GridUtil.Report=Por favor, reporta este error al autor de Tera Finder.
 GridUtil.RowsExceeded=Selección de filas superó el máximo permitido [1].
 GridUtil.MismatchGroupID=GroupID no coincide. La Teraincursión seleccionada sólo puede contener eventos con índice {editorIndex}. El resultado seleccionado tiene índice {resultIndex}.
+GridUtil.NoCatch=This Pokémon cannot be caught.

--- a/TeraFinder.Core/Resources/translations/lang_fr.txt
+++ b/TeraFinder.Core/Resources/translations/lang_fr.txt
@@ -361,3 +361,4 @@ GridUtil.CheckWiki=Please check the Tera Finder wiki to find out how to update t
 GridUtil.Report=Please report this error to the Tera Finder author.
 GridUtil.RowsExceeded=Rows selection exceeded the maximum allowed [1].
 GridUtil.MismatchGroupID=GroupID Mismatch. The selected Raid Den on the Raid Editor can only contain Event Raids with index {editorIndex}. The selected Raid result has Index {resultIndex}.
+GridUtil.NoCatch=This Pokémon cannot be caught.

--- a/TeraFinder.Core/Resources/translations/lang_it.txt
+++ b/TeraFinder.Core/Resources/translations/lang_it.txt
@@ -361,3 +361,4 @@ GridUtil.CheckWiki=Per favore controlla la wiki nella repository GitHub di Tera 
 GridUtil.Report=Per favore riporta questo errore all'autore di Tera Finder.
 GridUtil.RowsExceeded=Le righe selezionate vanno oltre il massimo consentito [1].
 GridUtil.MismatchGroupID=GroupID Mismatch. La Tana Raid selezionata può contenere solamente Raid Evento di Indice {editorIndex}. Il risultato selezionato ha Indice {resultIndex}.
+GridUtil.NoCatch=Questo Pokémon non può essere catturato.

--- a/TeraFinder.Core/Resources/translations/lang_ja.txt
+++ b/TeraFinder.Core/Resources/translations/lang_ja.txt
@@ -361,3 +361,4 @@ GridUtil.CheckWiki=Please check the Tera Finder wiki to find out how to update t
 GridUtil.Report=Please report this error to the Tera Finder author.
 GridUtil.RowsExceeded=Rows selection exceeded the maximum allowed [1].
 GridUtil.MismatchGroupID=GroupID Mismatch. The selected Raid Den on the Raid Editor can only contain Event Raids with index {editorIndex}. The selected Raid result has Index {resultIndex}.
+GridUtil.NoCatch=This Pokémon cannot be caught.

--- a/TeraFinder.Core/Resources/translations/lang_ko.txt
+++ b/TeraFinder.Core/Resources/translations/lang_ko.txt
@@ -361,3 +361,4 @@ GridUtil.CheckWiki=PKHeX.Core 종속성을 업데이트하는 방법에 대해�
 GridUtil.Report=오류를 테라파인더 제작자에게 보내주세요.
 GridUtil.RowsExceeded=선택한 항목이 허용된 최대 행 수[1]를 초과했습니다.
 GridUtil.MismatchGroupID=GroupID Mismatch. The selected Raid Den on the Raid Editor can only contain Event Raids with index {editorIndex}. The selected Raid result has Index {resultIndex}.
+GridUtil.NoCatch=This Pokémon cannot be caught.

--- a/TeraFinder.Core/Resources/translations/lang_zh-Hans.txt
+++ b/TeraFinder.Core/Resources/translations/lang_zh-Hans.txt
@@ -361,3 +361,4 @@ GridUtil.CheckWiki=请检查Tera Finder wiki以了解如何更新PKHeX.Core依�
 GridUtil.Report=请将此错误报告给Tera Finder作者。
 GridUtil.RowsExceeded=选择超出了允许的最大值[1]。
 GridUtil.MismatchGroupID=用户组不匹配。太晶洞窟编辑器上选定的太晶洞窟坑位只能包含索引为{editorIndex}的活动洞窟。所选洞窟结果的索引为{resultIndex}。
+GridUtil.NoCatch=This Pokémon cannot be caught.

--- a/TeraFinder.Core/Resources/translations/lang_zh-Hant.txt
+++ b/TeraFinder.Core/Resources/translations/lang_zh-Hant.txt
@@ -361,3 +361,4 @@ GridUtil.CheckWiki=請檢查Tera Finder wiki以了解如何更新PKHeX.Core依�
 GridUtil.Report=請將此錯誤報告給Tera Finder作者。
 GridUtil.RowsExceeded=選擇超出了允許的最大值[1]。
 GridUtil.MismatchGroupID=GroupID Mismatch. The selected Raid Den on the Raid Editor can only contain Event Raids with index {editorIndex}. The selected Raid result has Index {resultIndex}.
+GridUtil.NoCatch=This Pokémon cannot be caught.


### PR DESCRIPTION
Handle non-catchable raids / Language Updates Source Upstream Pull

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a check to prevent certain Pokémon encounters from being caught, with a user message displayed when catching is not possible.
  * Introduced a new message, "This Pokémon cannot be caught," with translations in multiple languages.

* **Bug Fixes**
  * Improved user feedback and control flow when attempting to catch Pokémon that cannot be caught.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->